### PR TITLE
Prevents pydantic to read from env variable unless it has the prefix.…

### DIFF
--- a/src/mapmos/config/parser.py
+++ b/src/mapmos/config/parser.py
@@ -29,7 +29,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from mapmos.config.config import (
     DataConfig,
@@ -40,6 +40,7 @@ from mapmos.config.config import (
 
 
 class MapMOSConfig(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="mapmos_")
     out_dir: str = "results"
     data: DataConfig = DataConfig()
     odometry: OdometryConfig = OdometryConfig()


### PR DESCRIPTION
… Brought to you by KISS: https://github.com/PRBonn/kiss-icp/commit/b2171736d66c1b413e1d36cfe513dd35d9173ce6