### PR TITLE
Add dev sandbox testing

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev pybind11
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev python3-pip
+          pip3 install pybind11
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
       - name: Build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -21,6 +21,8 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: "3.25.x"
+      - name: Install pybind
+        run:  python3 -m pip install pybind11[global]
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
       - name: Build
@@ -49,8 +51,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev python3-pip
-          pip3 install pybind11
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev
+      - name: Install pybind
+        run:  python3 -m pip install pybind11[global]
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
       - name: Build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,0 +1,56 @@
+name: C++ Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  cpp_api:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: "3.25.x"
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  # As the previous job will always install the dependencies from cmake, and this is guaranteed to
+  # work, we also want to support dev sandboxes where the main dependencies are already
+  # pre-installed in the system. For now, we only support dev machines under a GNU/Linux
+  # environmnets. If you are reading this and need the same functionallity in Windows/macOS please
+  # open a ticket.
+  cpp_api_dev:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.apt/cache
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/ubuntu_dependencies.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev pybind11
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/src/mapmos/pybind
       - name: Build

--- a/src/mapmos/pybind/CMakeLists.txt
+++ b/src/mapmos/pybind/CMakeLists.txt
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 cmake_minimum_required(VERSION 3.16...3.26)
-project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX VERSION "${SKBUILD_PROJECT_VERSION}")
+project(mapmos_cpp VERSION 1.0.0 LANGUAGES CXX)
 
 # Setup build options
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)

--- a/src/mapmos/pybind/Registration.cpp
+++ b/src/mapmos/pybind/Registration.cpp
@@ -26,6 +26,7 @@
 #include <tbb/global_control.h>
 #include <tbb/info.h>
 #include <tbb/parallel_reduce.h>
+#include <tbb/task_arena.h>
 
 #include <algorithm>
 #include <cmath>
@@ -171,7 +172,8 @@ Registration::Registration(int max_num_iteration, double convergence_criterion, 
     : max_num_iterations_(max_num_iteration),
       convergence_criterion_(convergence_criterion),
       // Only manipulate the number of threads if the user specifies something greater than 0
-      max_num_threads_(max_num_threads > 0 ? max_num_threads : tbb::info::default_concurrency()) {
+      max_num_threads_(max_num_threads > 0 ? max_num_threads
+                                           : tbb::this_task_arena::max_concurrency()) {
     // This global variable requires static duration storage to be able to manipulate the max
     // concurrency from TBB across the entire class
     static const auto tbb_control_settings = tbb::global_control(


### PR DESCRIPTION
Solves https://github.com/PRBonn/MapMOS/issues/27

The issue was already observed in KISS-ICP and solved by Nacho: https://github.com/PRBonn/kiss-icp/pull/361

When installing MapMOS on a system with an older version of TBB (like the one you get running `sudo apt install libtbb-dev` on Ubuntu 20.04), the build fails: https://github.com/PRBonn/MapMOS/actions/runs/10939530727/job/30369981192?pr=28

This PR takes the fix from KISS which fixes it. I also added the dev sandbox build check to the CI to catch such issues in the future.