### PR TITLE
Restrict KISS version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license_files = "LICENSE"
 dependencies = [
-    "kiss-icp>=1.0.0",
+    "kiss-icp<=1.1.0",
     "diskcache>=5.3.0",
     "pytorch_lightning>=1.6.4",
 ]


### PR DESCRIPTION
From KISS version `1.2.0` on, we do deskewing and clipping in the same module. In MapMOS however, we need to return an unclipped but deskewed version from the odometry. For now, I will restrict the version to be lower than `1.2.0` and will probably fix it in the future.