### PR TITLE
Add separate de-skewing

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.apt/cache
           key: ${{ runner.os }}-apt-${{ hashFiles('**/ubuntu_dependencies.yml') }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,5 +20,9 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Build pip package
         run: python -m pip install --verbose .
+      - name: Test pybind
+        run: python3 -c "from mapmos.pybind import mapmos_pybind"
+      - name: Test pipeline
+        run: python3 -c "from mapmos.pipeline import pipeline"
       - name: Test installation
         run: mapmos_pipeline --help

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,9 +20,5 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Build pip package
         run: python -m pip install --verbose .
-      - name: Test pybind
-        run: python3 -c "from mapmos.pybind import mapmos_pybind"
-      - name: Test pipeline
-        run: python3 -c "from mapmos.pipeline import pipeline"
       - name: Test installation
         run: mapmos_pipeline --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license_files = "LICENSE"
 dependencies = [
-    "kiss-icp<=1.1.0",
+    "kiss-icp>=1.2.0",
     "diskcache>=5.3.0",
     "pytorch_lightning>=1.6.4",
 ]

--- a/src/mapmos/mapping.py
+++ b/src/mapmos/mapping.py
@@ -59,7 +59,7 @@ class VoxelHashMap:
         self._internal_map._remove_far_away_points(location)
 
     def update_belief(self, points: np.ndarray, logits: np.ndarray):
-        self._internal_map._update_belief(mapmos_pybind._Vector3dVector(points), logits)
+        self._internal_map._update_belief(mapmos_pybind._Vector3dVector(points), logits.ravel())
 
     def get_belief(self, points: np.ndarray):
         belief = self._internal_map._get_belief(mapmos_pybind._Vector3dVector(points))

--- a/src/mapmos/odometry.py
+++ b/src/mapmos/odometry.py
@@ -97,10 +97,12 @@ class Odometry(KissICP):
 
     def deskew(self, points, timestamps, relative_motion):
         return (
-            mapmos_pybind._deskew(
-                frame=mapmos_pybind._Vector3dVector(points),
-                timestamps=timestamps.ravel(),
-                relative_motion=relative_motion,
+            np.asarray(
+                mapmos_pybind._deskew(
+                    frame=mapmos_pybind._Vector3dVector(points),
+                    timestamps=timestamps.ravel(),
+                    relative_motion=relative_motion,
+                )
             )
             if self.config.data.deskew
             else points

--- a/src/mapmos/odometry.py
+++ b/src/mapmos/odometry.py
@@ -20,14 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Type
-
 import numpy as np
 from kiss_icp.config import KISSConfig
 from kiss_icp.kiss_icp import KissICP, get_registration
 
 from mapmos.config import DataConfig, OdometryConfig
 from mapmos.mapping import VoxelHashMap
+from mapmos.pybind import mapmos_pybind
 from mapmos.registration import get_registration
 
 
@@ -61,13 +60,10 @@ class Odometry(KissICP):
 
     def register_points(self, points, timestamps, scan_index):
         # Apply motion compensation
-        points = self.compensator.deskew_scan(points, timestamps, self.last_delta)
-
-        # Preprocess the input cloud
-        points_prep = self.preprocess(points)
+        points = self.preprocessor.preprocess(points, timestamps, self.last_delta)
 
         # Voxelize
-        source, points_downsample = self.voxelize(points_prep)
+        source, points_downsample = self.voxelize(points)
 
         # Get motion prediction and adaptive_threshold
         sigma = self.adaptive_threshold.get_threshold()
@@ -92,17 +88,20 @@ class Odometry(KissICP):
         self.last_delta = np.linalg.inv(self.last_pose) @ new_pose
         self.last_pose = new_pose
 
-        points_reg = self.transform(points, self.last_pose)
-        return np.asarray(points_reg)
-
     def get_map_points(self):
         map_points, map_timestamps = self.local_map.point_cloud_with_timestamps()
         return map_points.reshape(-1, 3), map_timestamps.reshape(-1, 1)
 
-    def transform(self, points, pose):
-        points_hom = np.hstack((points, np.ones((len(points), 1))))
-        points = (pose @ points_hom.T).T[:, :3]
-        return points
-
     def current_location(self):
         return self.last_pose[:3, 3]
+
+    def deskew(self, points, timestamps, relative_motion):
+        return (
+            mapmos_pybind._deskew(
+                frame=mapmos_pybind._Vector3dVector(points),
+                timestamps=timestamps.ravel(),
+                relative_motion=relative_motion,
+            )
+            if self.config.data.deskew
+            else points
+        )

--- a/src/mapmos/paper_pipeline.py
+++ b/src/mapmos/paper_pipeline.py
@@ -72,10 +72,12 @@ class PaperPipeline(MapMOSPipeline):
         for scan_index in pbar:
             local_scan, timestamps, gt_labels = self._next(scan_index)
             map_points, map_indices = self.odometry.get_map_points()
+
+            last_delta = copy.copy(self.odometry.last_delta)
             self.odometry.register_points(local_scan, timestamps, scan_index)
             self.poses[scan_index - self._first] = self.odometry.last_pose
 
-            scan_points = self.odometry.deskew(local_scan, timestamps, self.odometry.last_delta)
+            scan_points = self.odometry.deskew(local_scan, timestamps, last_delta)
             scan_points = self._transform(scan_points, self.odometry.last_pose)
 
             min_range_mos = self.config.mos.min_range_mos

--- a/src/mapmos/paper_pipeline.py
+++ b/src/mapmos/paper_pipeline.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
 import time
 from pathlib import Path
 from typing import Optional

--- a/src/mapmos/paper_pipeline.py
+++ b/src/mapmos/paper_pipeline.py
@@ -72,8 +72,11 @@ class PaperPipeline(MapMOSPipeline):
         for scan_index in pbar:
             local_scan, timestamps, gt_labels = self._next(scan_index)
             map_points, map_indices = self.odometry.get_map_points()
-            scan_points = self.odometry.register_points(local_scan, timestamps, scan_index)
+            self.odometry.register_points(local_scan, timestamps, scan_index)
             self.poses[scan_index - self._first] = self.odometry.last_pose
+
+            scan_points = self.odometry.deskew(local_scan, timestamps, self.odometry.last_delta)
+            scan_points = self._transform(scan_points, self.odometry.last_pose)
 
             min_range_mos = self.config.mos.min_range_mos
             max_range_mos = self.config.mos.max_range_mos

--- a/src/mapmos/paper_pipeline.py
+++ b/src/mapmos/paper_pipeline.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import copy
 import time
 from pathlib import Path
 from typing import Optional
@@ -74,12 +73,8 @@ class PaperPipeline(MapMOSPipeline):
             local_scan, timestamps, gt_labels = self._next(scan_index)
             map_points, map_indices = self.odometry.get_map_points()
 
-            last_delta = copy.copy(self.odometry.last_delta)
-            self.odometry.register_points(local_scan, timestamps, scan_index)
+            scan_points = self.odometry.register_points(local_scan, timestamps, scan_index)
             self.poses[scan_index - self._first] = self.odometry.last_pose
-
-            scan_points = self.odometry.deskew(local_scan, timestamps, last_delta)
-            scan_points = self._transform(scan_points, self.odometry.last_pose)
 
             min_range_mos = self.config.mos.min_range_mos
             max_range_mos = self.config.mos.max_range_mos

--- a/src/mapmos/pipeline.py
+++ b/src/mapmos/pipeline.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
 import os
 import time
 from collections import deque
@@ -131,10 +132,12 @@ class MapMOSPipeline(OdometryPipeline):
         for scan_index in pbar:
             local_scan, timestamps, gt_labels = self._next(scan_index)
             map_points, map_indices = self.odometry.get_map_points()
+
+            last_delta = copy.copy(self.odometry.last_delta)
             self.odometry.register_points(local_scan, timestamps, scan_index)
             self.poses[scan_index - self._first] = self.odometry.last_pose
 
-            scan_points = self.odometry.deskew(local_scan, timestamps, self.odometry.last_delta)
+            scan_points = self.odometry.deskew(local_scan, timestamps, last_delta)
             scan_points = self._transform(scan_points, self.odometry.last_pose)
 
             min_range_mos = self.config.mos.min_range_mos

--- a/src/mapmos/pipeline.py
+++ b/src/mapmos/pipeline.py
@@ -120,14 +120,22 @@ class MapMOSPipeline(OdometryPipeline):
         mask = np.logical_and(mask, ranges >= min_range)
         return mask
 
+    def _transform(self, points, pose):
+        points_hom = np.hstack((points, np.ones((len(points), 1))))
+        points = (pose @ points_hom.T).T[:, :3]
+        return points
+
     # Private interface  ------
     def _run_pipeline(self):
         pbar = trange(self._first, self._last, unit=" frames", dynamic_ncols=True)
         for scan_index in pbar:
             local_scan, timestamps, gt_labels = self._next(scan_index)
             map_points, map_indices = self.odometry.get_map_points()
-            scan_points = self.odometry.register_points(local_scan, timestamps, scan_index)
+            self.odometry.register_points(local_scan, timestamps, scan_index)
             self.poses[scan_index - self._first] = self.odometry.last_pose
+
+            scan_points = self.odometry.deskew(local_scan, timestamps, self.odometry.last_delta)
+            scan_points = self._transform(scan_points, self.odometry.last_pose)
 
             min_range_mos = self.config.mos.min_range_mos
             max_range_mos = self.config.mos.max_range_mos

--- a/src/mapmos/pybind/CMakeLists.txt
+++ b/src/mapmos/pybind/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Python bindings
-pybind11_add_module(mapmos_pybind MODULE mapmos_pybind.cpp VoxelHashMap.cpp Registration.cpp)
+pybind11_add_module(mapmos_pybind MODULE mapmos_pybind.cpp VoxelHashMap.cpp Registration.cpp Deskew.cpp)
 target_compile_features(mapmos_pybind PRIVATE cxx_std_17)
 target_link_libraries(mapmos_pybind PUBLIC Eigen3::Eigen tsl::robin_map TBB::tbb Sophus::Sophus)
 install(TARGETS mapmos_pybind LIBRARY DESTINATION .)

--- a/src/mapmos/pybind/Deskew.cpp
+++ b/src/mapmos/pybind/Deskew.cpp
@@ -36,9 +36,6 @@ namespace mapmos {
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion) {
-    static const auto tbb_control_settings = tbb::global_control(
-        tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
-
     const std::vector<Eigen::Vector3d> &deskewed_frame = [&]() {
         const auto &omega = relative_motion.log();
         const Sophus::SE3d &inverse_motion = relative_motion.inverse();

--- a/src/mapmos/pybind/Deskew.cpp
+++ b/src/mapmos/pybind/Deskew.cpp
@@ -23,11 +23,7 @@
 #include "Deskew.hpp"
 
 #include <tbb/blocked_range.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/global_control.h>
-#include <tbb/info.h>
 #include <tbb/parallel_for.h>
-#include <tbb/task_arena.h>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -40,9 +36,6 @@ namespace mapmos {
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion) {
-    static const auto tbb_control_settings = tbb::global_control(
-        tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
-
     const std::vector<Eigen::Vector3d> &deskewed_frame = [&]() {
         const auto &omega = relative_motion.log();
         const Sophus::SE3d &inverse_motion = relative_motion.inverse();

--- a/src/mapmos/pybind/Deskew.cpp
+++ b/src/mapmos/pybind/Deskew.cpp
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2022 Ignacio Vizzo, Tiziano Guadagnino, Benedikt Mersch, Cyrill
+// Stachniss.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "Deskew.hpp"
+
+#include <tbb/blocked_range.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/global_control.h>
+#include <tbb/info.h>
+#include <tbb/parallel_for.h>
+#include <tbb/task_arena.h>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+namespace mapmos {
+static const auto tbb_control_settings = tbb::global_control(
+    tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
+
+std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
+                                    const std::vector<double> &timestamps,
+                                    const Sophus::SE3d &relative_motion) {
+    const std::vector<Eigen::Vector3d> &deskewed_frame = [&]() {
+        const auto &omega = relative_motion.log();
+        const Sophus::SE3d &inverse_motion = relative_motion.inverse();
+        std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
+        tbb::parallel_for(
+            // Index Range
+            tbb::blocked_range<size_t>{0, deskewed_frame.size()},
+            // Parallel Compute
+            [&](const tbb::blocked_range<size_t> &r) {
+                for (size_t idx = r.begin(); idx < r.end(); ++idx) {
+                    const auto &point = frame.at(idx);
+                    const auto &stamp = timestamps.at(idx);
+                    const auto pose = inverse_motion * Sophus::SE3d::exp(stamp * omega);
+                    deskewed_frame.at(idx) = pose * point;
+                };
+            });
+        return deskewed_frame;
+    }();
+    return deskewed_frame;
+}
+}  // namespace mapmos

--- a/src/mapmos/pybind/Deskew.cpp
+++ b/src/mapmos/pybind/Deskew.cpp
@@ -36,12 +36,13 @@
 #include <vector>
 
 namespace mapmos {
-static const auto tbb_control_settings = tbb::global_control(
-    tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
 
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion) {
+    static const auto tbb_control_settings = tbb::global_control(
+        tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
+
     const std::vector<Eigen::Vector3d> &deskewed_frame = [&]() {
         const auto &omega = relative_motion.log();
         const Sophus::SE3d &inverse_motion = relative_motion.inverse();
@@ -62,4 +63,5 @@ std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
     }();
     return deskewed_frame;
 }
+
 }  // namespace mapmos

--- a/src/mapmos/pybind/Deskew.cpp
+++ b/src/mapmos/pybind/Deskew.cpp
@@ -36,6 +36,9 @@ namespace mapmos {
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion) {
+    static const auto tbb_control_settings = tbb::global_control(
+        tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
+
     const std::vector<Eigen::Vector3d> &deskewed_frame = [&]() {
         const auto &omega = relative_motion.log();
         const Sophus::SE3d &inverse_motion = relative_motion.inverse();

--- a/src/mapmos/pybind/Deskew.hpp
+++ b/src/mapmos/pybind/Deskew.hpp
@@ -1,0 +1,33 @@
+// MIT License
+//
+// Copyright (c) 2022 Ignacio Vizzo, Tiziano Guadagnino, Benedikt Mersch, Cyrill
+// Stachniss.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <Eigen/Core>
+#include <sophus/se3.hpp>
+#include <vector>
+
+namespace mapmos {
+std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
+                                    const std::vector<double> &timestamps,
+                                    const Sophus::SE3d &relative_motion);
+}  // namespace mapmos

--- a/src/mapmos/pybind/Deskew.hpp
+++ b/src/mapmos/pybind/Deskew.hpp
@@ -21,13 +21,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #pragma once
+#include <tbb/global_control.h>
+#include <tbb/task_arena.h>
 
 #include <Eigen/Core>
 #include <sophus/se3.hpp>
 #include <vector>
 
 namespace mapmos {
+
+static const auto tbb_control_settings = tbb::global_control(
+    tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
+
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion);
+
 }  // namespace mapmos

--- a/src/mapmos/pybind/Deskew.hpp
+++ b/src/mapmos/pybind/Deskew.hpp
@@ -30,9 +30,6 @@
 
 namespace mapmos {
 
-static const auto tbb_control_settings = tbb::global_control(
-    tbb::global_control::max_allowed_parallelism, tbb::this_task_arena::max_concurrency());
-
 std::vector<Eigen::Vector3d> Deskew(const std::vector<Eigen::Vector3d> &frame,
                                     const std::vector<double> &timestamps,
                                     const Sophus::SE3d &relative_motion);

--- a/src/mapmos/pybind/mapmos_pybind.cpp
+++ b/src/mapmos/pybind/mapmos_pybind.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <vector>
 
+#include "Deskew.hpp"
 #include "Registration.hpp"
 #include "VoxelHashMap.hpp"
 #include "stl_vector_eigen.h"
@@ -44,6 +45,15 @@ PYBIND11_MODULE(mapmos_pybind, m) {
     auto vector3dvector = pybind_eigen_vector_of_vector<Eigen::Vector3d>(
         m, "_Vector3dVector", "std::vector<Eigen::Vector3d>",
         py::py_array_to_vectors_double<Eigen::Vector3d>);
+
+    m.def(
+        "_deskew",
+        [](const std::vector<Eigen::Vector3d> &points, const std::vector<double> &timestamps,
+           const Eigen::Matrix4d &relative_motion) {
+            Sophus::SE3d motion(relative_motion);
+            return Deskew(points, timestamps, motion);
+        },
+        "frame"_a, "timestamps"_a, "relative_motion"_a);
 
     // Map representation
     py::class_<VoxelHashMap> internal_map(m, "_VoxelHashMap", "Don't use this");


### PR DESCRIPTION
This PR moves to the latest KISS version `1.2.0`. Since max_range clipping and deskewing now happen jointly in the KISS preprocessing module, I added a separate de-skewing of the raw frame after registration, which is then used for MOS. With this, we maintain complete control over the number of points since we use different `max_range` and `min_range` parameters for MOS.